### PR TITLE
feat(gha): created a CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         version: [ '7.4', '8.0', '8.1' ]
+        symfony-version: [ '4.4.*', '5.4.*', '6.*' ]
         composer-options: [ '', '--prefer-lowest' ]
       fail-fast: false
     steps:
@@ -15,5 +16,6 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.version }}
+      - run: composer config extra.symfony.require "${{ matrix.symfony-version }}"
       - run: composer update ${{ matrix.composer-options }}
       - run: make quality test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,15 +7,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ '7.4', '8.0', '8.1' ]
+        php-version: [ '7.4', '8.0', '8.1' ]
         symfony-version: [ '4.4.*', '5.4.*', '6.*' ]
         composer-options: [ '', '--prefer-lowest' ]
+        exclude:
+          - php-version: '7.4'
+            symfony-version: '6.*'
       fail-fast: false
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.version }}
+          php-version: ${{ matrix.php-version }}
       - run: composer config extra.symfony.require "${{ matrix.symfony-version }}"
       - run: composer update ${{ matrix.composer-options }}
       - run: make quality test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: Continuous Integration
+on: [pull_request]
+
+jobs:
+  ci:
+    name: Quality & Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [ '7.4', '8.0', '8.1' ]
+        composer-options: [ '', '--prefer-lowest' ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@master
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.version }}
+      - run: composer update ${{ matrix.composer-options }}
+      - run: make quality test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,13 @@
 /bin/
 /vendor/
-/.php-cs-fixer.cache
-/.phpunit.result.cache
 /composer.lock
+
+###> friendsofphp/php-cs-fixer ###
+/.php-cs-fixer.php
+/.php-cs-fixer.cache
+###< friendsofphp/php-cs-fixer ###
+
+###> phpunit/phpunit ###
+/phpunit.xml
+.phpunit.result.cache
+###< phpunit/phpunit ###

--- a/Makefile
+++ b/Makefile
@@ -11,22 +11,19 @@ define printSection
 endef
 
 .PHONY: all
-all: install quality test tool-ci-all
-
-.PHONY: ci
-ci: install quality test tool-ci-all
+all: install quality test
 
 .PHONY: install
 install: clean-vendor composer-install
 
 .PHONY: quality
-quality: cs-ci phpstan
+quality: rector cs phpstan
 
 .PHONY: quality-fix
-quality-fix: cs-fix
+quality-fix: rector-fix cs-fix
 
 .PHONY: test
-test: cs rector phpstan phpunit
+test: phpunit
 
 # Coding Style
 
@@ -38,10 +35,6 @@ cs:
 .PHONY: cs-fix
 cs-fix:
 	${BIN_DIR}/php-cs-fixer fix
-
-.PHONY: cs-ci
-cs-ci:
-	${BIN_DIR}/php-cs-fixer fix --ansi --dry-run --using-cache=no --verbose
 
 #COMPOSER
 
@@ -56,13 +49,6 @@ clean-vendor:
 composer-install:
 	$(call printSection,COMPOSER INSTALL)
 	${COMPOSER_BIN} update --no-interaction --ansi --no-progress
-
-# CI TOOLS
-${CI_DIR}:
-	git clone --depth=1 https://github.m6web.fr/m6web/tool-php-ci.git ${CI_DIR}
-
-tool-ci-%: ${CI_DIR}
-	make -e SOURCE_DIR=${SOURCE_DIR} -e CI_DIR=${CI_DIR} -f ${CI_DIR}/Makefile $@
 
 # TEST
 .PHONY: phpunit
@@ -79,3 +65,8 @@ phpstan:
 rector:
 	$(call printSection,Test Rector)
 	${BIN_DIR}/rector process --dry-run
+
+.PHONY: rector-fix
+rector-fix:
+	$(call printSection,Execute Rector)
+	${BIN_DIR}/rector process

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=bash
 SOURCE_DIR = $(shell pwd)
 BIN_DIR = ${SOURCE_DIR}/bin
-COMPOSER_BIN ?= composer2
+COMPOSER_BIN ?= composer
 CI_DIR = ${BIN_DIR}/tool-php-ci
 
 define printSection
@@ -49,6 +49,24 @@ clean-vendor:
 composer-install:
 	$(call printSection,COMPOSER INSTALL)
 	${COMPOSER_BIN} update --no-interaction --ansi --no-progress
+
+.PHONY: composer-install-sf4
+composer-install-sf4:
+	composer config extra.symfony.require "4.4.*"
+	${MAKE} composer-install
+	composer config --unset extra
+
+.PHONY: composer-install-sf5
+composer-install-sf5:
+	composer config extra.symfony.require "5.4.*"
+	${MAKE} composer-install
+	composer config --unset extra
+
+.PHONY: composer-install-sf6
+composer-install-sf6:
+	composer config extra.symfony.require "6.*"
+	${MAKE} composer-install
+	composer config --unset extra
 
 # TEST
 .PHONY: phpunit

--- a/README.md
+++ b/README.md
@@ -45,10 +45,13 @@ It should not be enabled in a production environment since it can cause performa
 
 ## Contribute
 
-You can execute `make test` to execute all tests.
+You can execute `make quality test` to execute quality checks and tests.
+There is also a few make targets that can help you check this bundle is correctly supported on every Symfony versions
+* `make composer-install-sf4`
+* `make composer-install-sf5`
+* `make composer-install-sf6`
 
 ## TODO before release
 
-* [ ] Create Github Actions to execute tests
 * [ ] Cleanup configuration
 * [ ] Create version 1.0 for Symfony 5.4 + PHP 7.4 and version 2.0 for Symfony 6.0 and PHP 8.0, using branch `feat/php8`

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     "m6web/php-cs-fixer-config": "^2.0",
     "phpstan/phpstan": "^1.6",
     "rector/rector": "^0.13.8",
-    "symfony/polyfill-php80": "^1.16.0"
+    "symfony/polyfill-php80": "^1.16.0",
+    "friendsofphp/php-cs-fixer": "^3.4.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
     }
   },
   "config": {
-    "bin-dir": "bin/"
+    "bin-dir": "bin/",
+    "allow-plugins": {
+      "symfony/flex": true
+    }
   },
   "authors": [
     {
@@ -40,6 +43,7 @@
     "phpstan/phpstan": "^1.6",
     "rector/rector": "^0.13.8",
     "symfony/polyfill-php80": "^1.16.0",
-    "friendsofphp/php-cs-fixer": "^3.4.0"
+    "friendsofphp/php-cs-fixer": "^3.4.0",
+    "symfony/flex": "^1.19 || ^2.2"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
     "phpspec/prophecy-phpunit": "^2.0",
     "m6web/php-cs-fixer-config": "^2.0",
     "phpstan/phpstan": "^1.6",
-    "rector/rector": "^0.13.8"
+    "rector/rector": "^0.13.8",
+    "symfony/polyfill-php80": "^1.16.0"
   }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,0 +1,61 @@
+{
+    "doctrine/annotations": {
+        "version": "1.13",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.10",
+            "ref": "64d8583af5ea57b7afa4aba4b159907f3a148b05"
+        }
+    },
+    "friendsofphp/php-cs-fixer": {
+        "version": "3.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.0",
+            "ref": "be2103eb4a20942e28a6dd87736669b757132435"
+        },
+        "files": [
+            ".php-cs-fixer.dist.php"
+        ]
+    },
+    "phpunit/phpunit": {
+        "version": "9.5",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "9.3",
+            "ref": "a6249a6c4392e9169b87abf93225f7f9f59025e6"
+        },
+        "files": [
+            ".env.test",
+            "phpunit.xml.dist",
+            "tests/bootstrap.php"
+        ]
+    },
+    "symfony/console": {
+        "version": "6.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.3",
+            "ref": "da0c8be8157600ad34f10ff0c9cc91232522e047"
+        },
+        "files": [
+            "bin/console"
+        ]
+    },
+    "symfony/flex": {
+        "version": "2.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "146251ae39e06a95be0fe3d13c807bcf3938b172"
+        },
+        "files": [
+            ".env"
+        ]
+    }
+}


### PR DESCRIPTION
## Description

Add a GHA CI workflow to test
* coding style
* rector rules application
* phpstan checks
* phpunit tests

This should run for a bunch of supported PHP & Symfony versions.

Note that I had to add a few dev dependency to correctly work around some limitations
* `symfony/polyfill-php80 ^1.16` to allow rector using str_starts_with
* `friendsofphp/php-cs-fixer ^3.4` to allow php ^8.1
* `symfony/flex` to allow playing with composer "extra.symfony.require" to dynamically force Symfony versions
    - I had to commit the `symfony.lock` file too to prevent flex from adding (invalid) default files during composer installation