### PR TITLE
feat(config): use config definition to validate input

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,5 +53,4 @@ There is also a few make targets that can help you check this bundle is correctl
 
 ## TODO before release
 
-* [ ] Cleanup configuration
 * [ ] Create version 1.0 for Symfony 5.4 + PHP 7.4 and version 2.0 for Symfony 6.0 and PHP 8.0, using branch `feat/php8`

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,8 +18,14 @@ class Configuration implements ConfigurationInterface
         $treeBuilder->getRootNode()
             ->children()
             ->arrayNode('decorated_cache_pools')
-            // TODO declare subkeys
-            ->variablePrototype();
+                ->useAttributeAsKey('stale_service_id')
+                ->arrayPrototype()
+                    ->children()
+                        ->scalarNode('cache_pool')->isRequired()->cannotBeEmpty()->end()
+                        ->integerNode('max_stale')->isRequired()->end()
+                        ->booleanNode('enable_debug_logs')->defaultFalse()->end()
+                    ->end()
+                ->end();
 
         return $treeBuilder;
     }


### PR DESCRIPTION
## Description

Config definition should provide a more easy way to configure the bundle by telling to the user the possible configuration, and possible mistakes.

See this example : 

```
$ ./bin/console config:dump-reference bedrock_stale_cache
# Default configuration for extension with alias: "bedrock_stale_cache"
bedrock_stale_cache:
    decorated_cache_pools:

        # Prototype
        stale_service_id:
            cache_pool:           ~ # Required
            max_stale:            ~ # Required
            enable_debug_logs:    false
```